### PR TITLE
US-24.1: Fix completed tasks to retain sprint information

### DIFF
--- a/507site/main/templates/main/completed_tasks.html
+++ b/507site/main/templates/main/completed_tasks.html
@@ -96,13 +96,15 @@
                                     </small>
                                 </td>
                                 <td>
-                                    {% if task.sprint %}
-                                        <span class="badge bg-primary">{{ task.sprint.name }}</span>
-                                    {% else %}
-                                        <span class="text-muted">No Sprint</span>
-                                    {% endif %}
+                                        {% if task.planned_sprint %}
+                                            <span class="badge bg-primary">{{ task.planned_sprint.name }}</span>
+                                        {% elif task.sprint %}
+                                            <span class="badge bg-primary">{{ task.sprint.name }}</span>
+                                        {% else %}
+                                            <span class="text-muted">No Sprint</span>
+                                        {% endif %}
                                 </td>
-                                <td class="text-center">
+                                <td class="text-center" style="white-space: nowrap;">
                                     <span class="badge bg-light text-dark">{{ task.story_points }} pts</span>
                                 </td>
                                 <td>
@@ -134,7 +136,7 @@
             </div>
         </div>
 
-        <!-- Tasks Grouped by Sprint (Optional Alternative View) -->
+        <!-- Tasks Grouped by Sprint-->
         <div class="mt-4">
             <h3>Tasks by Sprint</h3>
             {% for sprint_name, sprint_tasks in tasks_by_sprint.items %}

--- a/507site/main/views.py
+++ b/507site/main/views.py
@@ -1065,7 +1065,9 @@ def completed_tasks(request):
     # Group tasks by sprint for display
     tasks_by_sprint = {}
     for task in tasks:
-        sprint_name = task.sprint.name if task.sprint else 'No Sprint'
+        sprint_name = (task.planned_sprint.name if task.planned_sprint 
+                    else task.sprint.name if task.sprint 
+                    else 'No Sprint')
         if sprint_name not in tasks_by_sprint:
             tasks_by_sprint[sprint_name] = []
         tasks_by_sprint[sprint_name].append(task)
@@ -1078,6 +1080,15 @@ def completed_tasks(request):
         'sprints': sprints,
         'selected_sprint': sprint_filter,
     }
+    sprint_completion_data = defaultdict(lambda: {'count': 0, 'points': 0})
+    for task in tasks:
+        sprint_key = (task.planned_sprint.name if task.planned_sprint 
+                    else task.sprint.name if task.sprint 
+                    else 'No Sprint')
+        sprint_completion_data[sprint_key]['count'] += 1
+        sprint_completion_data[sprint_key]['points'] += (task.story_points or 0)
+
+    context['sprint_completion_data'] = dict(sprint_completion_data)
     
     return render(request, 'main/completed_tasks.html', context)
 


### PR DESCRIPTION
## Sprint Workflow & Testing Integration - Critical Bug Fixes

### Summary
Fixed critical bugs in sprint completion and testing workflow that caused tasks to lose sprint tracking and disappear from reports.

### Issues Fixed
- **US-24.1**: Completed tasks retain sprint information via `planned_sprint` reference
- **Completed Tasks View**: Shows which sprint tasks were completed in, fixed table alignment

close #82 